### PR TITLE
fix:画面遷移がうまくいかないものを修正

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html, :turbo_stream]
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :get


### PR DESCRIPTION
profileに遷移するためにユーザー名を押すと一度ログイン画面に遷移してしまうバグの修正

Deviseがturbo_stream形式のリクエストをAPIリクエストと判断
認証成功でも401を返してしまい、セッションが正しく確立されない
その状態でprofileにアクセスすると未認証扱いでログインページに飛ばされる

config.navigational_formats = ['*/*', :html, :turbo_stream]
の追加でTurboのリクエストもHTMLと同様に「ログイン後はリダイレクト」という通常の流れで処理されるようにした