### PR TITLE
fix: ログアウトリンクのTurboプリフェッチを無効化しroot_pathに戻す

### DIFF
--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -1,14 +1,15 @@
 <% content_for :title, "タイムライン - sengen" %>
+<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
   <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
-    <%= link_to declarations_path do %>
+    <%= link_to root_path do %>
       <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
     <% end %>
     <div class="flex items-center gap-3">
       <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
-      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors" %>
+      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors", data: { turbo_prefetch: false } %>
     </div>
   </div>
 </nav>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, "プロフィール編集 - sengen" %>
+<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
   <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
-    <%= link_to declarations_path do %>
+    <%= link_to root_path do %>
       <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
     <% end %>
     <div class="flex items-center gap-3">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,14 +1,15 @@
 <% content_for :title, "プロフィール - sengen" %>
+<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
   <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
-    <%= link_to declarations_path do %>
+    <%= link_to root_path do %>
       <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
     <% end %>
     <div class="flex items-center gap-3">
-      <%= link_to "ホーム", declarations_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
-      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors" %>
+      <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors", data: { turbo_prefetch: false } %>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
ボタンを押すとログインページに誤遷移してしまうことがあることの修正
pathを変更し、対策を試みたが変わらずだったため、Turboプリフェッチを無効化
そのためpathもroot_pathに戻した