### PR TITLE
fix: Active JobをインラインにしてSolidQueue依存を解消

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,8 +50,7 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  config.active_job.queue_adapter = :inline
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
編集画面にて、プロフィール画像を変更し保存しようとすると500エラー発生。
インラインで即座に実行させる
