### PR TITLE
fix: SolidQueueを正しく設定しActiveStorage保存時の500エラーを修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Active Jobのキューアダプターを:inlineから:solid_queueに戻す                                              
   - SolidQueue.connects_toの設定を追加し、Pumaプラグインが                                                   
     正常に起動できるようにする                                                                               
   - db/queue_schema.rbが既にコミット済みのため、Renderデプロイ時に                                           
     db:prepareでSolidQueueテーブルが自動作成される