### PR TITLE
feat: 未達成の宣言を赤色で表示 #82

### DIFF
--- a/app/jobs/expire_declarations_job.rb
+++ b/app/jobs/expire_declarations_job.rb
@@ -1,0 +1,7 @@
+class ExpireDeclarationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Declaration.declaring.where("deadline < ?", Date.today).update_all(status: :pending)
+  end
+end

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -87,7 +87,7 @@
       </div>
     <% else %>
       <% @declarations.each do |declaration| %>
-        <div class="rounded-2xl shadow-sm p-5 <%= declaration.completed? ? 'bg-blue-100 border border-blue-200' : 'bg-white border border-gray-200' %>">
+        <div class="rounded-2xl shadow-sm p-5 <%= if declaration.completed? then 'bg-blue-100 border border-blue-200' elsif declaration.pending? then 'bg-red-100 border border-red-200' else 'bg-white border border-gray-200' end %>">
           <div class="flex gap-3">
             <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
               <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -96,7 +96,7 @@
             </div>
             <div class="flex-1 min-w-0">
               <p class="font-bold text-gray-800 mb-2"><%= declaration.user.name %></p>
-              <div class="rounded-lg px-4 py-3 mb-3 <%= declaration.completed? ? 'bg-white' : 'bg-gray-50' %>">
+              <div class="rounded-lg px-4 py-3 mb-3 <%= if declaration.completed? || declaration.pending? then 'bg-white' else 'bg-gray-50' end %>">
                 <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
               </div>
               <div class="flex items-center justify-between">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -146,16 +146,16 @@
           </div>
         <% else %>
           <% @pending.each do |declaration| %>
-            <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5">
+            <div class="bg-red-100 rounded-2xl shadow-sm border border-red-200 p-5">
               <div class="flex gap-3">
-                <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-                  <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="h-10 w-10 rounded-full bg-red-50 flex items-center justify-center shrink-0">
+                  <svg class="h-6 w-6 text-red-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
                   </svg>
                 </div>
                 <div class="flex-1 min-w-0">
                   <p class="font-bold text-gray-800 mb-2"><%= current_user.name %></p>
-                  <div class="bg-gray-50 rounded-lg px-4 py-3 mb-3">
+                  <div class="bg-white rounded-lg px-4 py-3 mb-3">
                     <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
                   </div>
                   <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  expire_declarations:
+    class: ExpireDeclarationsJob
+    schedule: at 0am every day


### PR DESCRIPTION
## Summary
- 期限切れの宣言を自動で未達成（pending）に変更するバッチジョブを追加
- タイムライン・プロフィールで未達成カードを赤色で表示

## 変更内容
- `app/jobs/expire_declarations_job.rb` — 毎日0時に期限切れ宣言をpendingに更新
- `config/recurring.yml` — ジョブのスケジュール登録
- `app/views/declarations/index.html.erb` — 未達成カードを赤色に
- `app/views/profiles/show.html.erb` — 未達成パネルのカードを赤色に

Closes #82