### PR TITLE
fix: ActiveStorageの画像URL有効期限を無期限に変更 #112

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.active_storage.urls_expire_in = nil
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # config.assume_ssl = true


### PR DESCRIPTION
- ActiveStorageのsigned URLのデフォルト有効期限（5分）を無期限に変更
- プロフィール画像が時間経過で表示されなくなる問題を修正

Closes #112