### PR TITLE
feat: タイムラインの宣言カードにアバター画像を表示 #114

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -2,7 +2,7 @@ class DeclarationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @declarations = Declaration.includes(:user).recent
+    @declarations = Declaration.includes(user: { avatar_attachment: :blob }).recent
     @declaration = Declaration.new(deadline: Date.today)
   end
 
@@ -11,7 +11,7 @@ class DeclarationsController < ApplicationController
     if @declaration.save
       redirect_to root_path, notice: t("declarations.notices.created")
     else
-      @declarations = Declaration.includes(:user).recent
+      @declarations = Declaration.includes(user: { avatar_attachment: :blob }).recent
       flash.now[:alert] = @declaration.errors.full_messages.first
       render :index, status: :unprocessable_entity
     end

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -89,10 +89,14 @@
       <% @declarations.each do |declaration| %>
         <div class="rounded-2xl shadow-sm p-5 <%= if declaration.completed? then 'bg-blue-100 border border-blue-200' elsif declaration.pending? then 'bg-red-100 border border-red-200' else 'bg-white border border-gray-200' end %>">
           <div class="flex gap-3">
-            <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-              <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-              </svg>
+            <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+              <% if declaration.user.avatar.attached? %>
+                <%= image_tag declaration.user.avatar, class: "h-full w-full object-cover" %>
+              <% else %>
+                <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                </svg>
+              <% end %>
             </div>
             <div class="flex-1 min-w-0">
               <p class="font-bold text-gray-800 mb-2"><%= declaration.user.name %></p>


### PR DESCRIPTION
- タイムラインの宣言カードにユーザーのアバター画像を表示
- アバター未設定の場合はデフォルトのSVGアイコンを表示
- N+1クエリ対策でavatarのeager loadingを追加

Closes #114