### PR TITLE
feat: 他ユーザーのプロフィールページを追加 #118

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,13 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = User.find(params[:id])
+    @declarations = @user.declarations.recent
+    @declaring = @declarations.declaring
+    @pending = @declarations.pending
+    @completed = @declarations.completed
+    judged = @pending.count + @completed.count
+    @completion_rate = judged > 0 ? (@completed.count * 100 / judged) : 0
+  end
+end

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -99,7 +99,7 @@
               <% end %>
             </div>
             <div class="flex-1 min-w-0">
-              <p class="font-bold text-gray-800 mb-2"><%= declaration.user.name %></p>
+              <p class="font-bold text-gray-800 mb-2"><%= link_to declaration.user.name, user_path(declaration.user), class: "hover:underline" %></p>
               <div class="rounded-lg px-4 py-3 mb-3 <%= if declaration.completed? || declaration.pending? then 'bg-white' else 'bg-gray-50' end %>">
                 <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
               </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,197 @@
+<% content_for :title, "#{@user.name} - sengen" %>
+<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
+<!-- ナビバー -->
+<nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
+  <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
+    <% end %>
+    <div class="flex items-center gap-3">
+      <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
+    </div>
+  </div>
+</nav>
+
+<div class="min-h-screen bg-gray-50 pt-16">
+  <div class="max-w-2xl mx-auto px-4 py-6 space-y-4">
+
+    <!-- プロフィールカード -->
+    <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5">
+      <div class="flex items-start gap-4">
+        <div class="h-14 w-14 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+          <% if @user.avatar.attached? %>
+            <%= image_tag @user.avatar, class: "h-full w-full object-cover" %>
+          <% else %>
+            <svg class="h-8 w-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+            </svg>
+          <% end %>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="font-bold text-gray-800 text-lg"><%= @user.name %></p>
+          <% if @user.bio.present? %>
+            <p class="text-gray-500 text-sm mt-2 leading-relaxed"><%= @user.bio %></p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <!-- 統計 -->
+    <div class="grid grid-cols-5 gap-3">
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p class="text-2xl font-bold text-gray-800"><%= @declarations.count %></p>
+        <p class="text-xs text-gray-400 mt-1">宣言数</p>
+      </div>
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p class="text-2xl font-bold text-gray-800"><%= @declaring.count %></p>
+        <p class="text-xs text-gray-400 mt-1">宣言中</p>
+      </div>
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p class="text-2xl font-bold text-gray-800"><%= @pending.count %></p>
+        <p class="text-xs text-gray-400 mt-1">未達成</p>
+      </div>
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p class="text-2xl font-bold text-gray-800"><%= @completed.count %></p>
+        <p class="text-xs text-gray-400 mt-1">達成</p>
+      </div>
+      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p class="text-2xl font-bold text-gray-800"><%= @completion_rate %>%</p>
+        <p class="text-xs text-gray-400 mt-1">達成率</p>
+      </div>
+    </div>
+
+    <!-- タブ -->
+    <div data-controller="tabs">
+      <div class="flex border-b border-gray-200 bg-white rounded-t-2xl overflow-hidden">
+        <button
+          data-tabs-target="tab"
+          data-tab="declaring"
+          data-action="click->tabs#switch"
+          class="flex-1 py-3 text-sm font-semibold border-b-2 border-blue-600 text-blue-600 transition-colors">
+          宣言中（<%= @declaring.count %>）
+        </button>
+        <button
+          data-tabs-target="tab"
+          data-tab="pending"
+          data-action="click->tabs#switch"
+          class="flex-1 py-3 text-sm font-semibold border-b-2 border-transparent text-gray-500 transition-colors">
+          未達成（<%= @pending.count %>）
+        </button>
+        <button
+          data-tabs-target="tab"
+          data-tab="completed"
+          data-action="click->tabs#switch"
+          class="flex-1 py-3 text-sm font-semibold border-b-2 border-transparent text-gray-500 transition-colors">
+          達成（<%= @completed.count %>）
+        </button>
+      </div>
+
+      <!-- 宣言中パネル -->
+      <div data-tabs-target="panel" data-panel="declaring" class="space-y-3 pt-3">
+        <% if @declaring.empty? %>
+          <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+            <p class="text-sm">宣言中の宣言はありません</p>
+          </div>
+        <% else %>
+          <% @declaring.each do |declaration| %>
+            <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-5">
+              <div class="flex gap-3">
+                <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+                  <% if @user.avatar.attached? %>
+                    <%= image_tag @user.avatar, class: "h-full w-full object-cover" %>
+                  <% else %>
+                    <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                    </svg>
+                  <% end %>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class="font-bold text-gray-800 mb-2"><%= @user.name %></p>
+                  <div class="bg-gray-50 rounded-lg px-4 py-3 mb-3">
+                    <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
+                  </div>
+                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <!-- 未達成パネル -->
+      <div data-tabs-target="panel" data-panel="pending" class="hidden space-y-3 pt-3">
+        <% if @pending.empty? %>
+          <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+            <p class="text-sm">未達成の宣言はありません</p>
+          </div>
+        <% else %>
+          <% @pending.each do |declaration| %>
+            <div class="bg-red-100 rounded-2xl shadow-sm border border-red-200 p-5">
+              <div class="flex gap-3">
+                <div class="h-10 w-10 rounded-full bg-red-50 flex items-center justify-center shrink-0 overflow-hidden">
+                  <% if @user.avatar.attached? %>
+                    <%= image_tag @user.avatar, class: "h-full w-full object-cover" %>
+                  <% else %>
+                    <svg class="h-6 w-6 text-red-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                    </svg>
+                  <% end %>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class="font-bold text-gray-800 mb-2"><%= @user.name %></p>
+                  <div class="bg-white rounded-lg px-4 py-3 mb-3">
+                    <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
+                  </div>
+                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <!-- 達成パネル -->
+      <div data-tabs-target="panel" data-panel="completed" class="hidden space-y-3 pt-3">
+        <% if @completed.empty? %>
+          <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+            <p class="text-sm">達成した宣言はありません</p>
+          </div>
+        <% else %>
+          <% @completed.each do |declaration| %>
+            <div class="bg-blue-100 rounded-2xl shadow-sm border border-blue-200 p-5">
+              <div class="flex gap-3">
+                <div class="h-10 w-10 rounded-full bg-blue-50 flex items-center justify-center shrink-0 overflow-hidden">
+                  <% if @user.avatar.attached? %>
+                    <%= image_tag @user.avatar, class: "h-full w-full object-cover" %>
+                  <% else %>
+                    <svg class="h-6 w-6 text-blue-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                    </svg>
+                  <% end %>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class="font-bold text-gray-800 mb-2"><%= @user.name %></p>
+                  <div class="bg-white rounded-lg px-4 py-3 mb-3">
+                    <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                    <span class="flex items-center gap-1.5 text-green-600 text-sm font-semibold bg-green-50 px-4 py-1.5 rounded-full">
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                      </svg>
+                      達成済み
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   root "pages#landing"
 
   resource :profile, only: [ :show, :edit, :update ]
+  resources :users, only: [ :show ]
 
   resources :declarations, only: [ :index, :create ] do
     member do


### PR DESCRIPTION
- `/users/:id` で他ユーザーのプロフィールページを表示できるようにした
- UsersController#showを新規作成
- タイムラインのユーザー名をクリックでプロフィールに遷移するようリンク化

## 変更ファイル
- `app/controllers/users_controller.rb`（新規）
- `app/views/users/show.html.erb`（新規）
- `config/routes.rb`（`resources :users, only: [:show]` 追加）
- `app/views/declarations/index.html.erb`（ユーザー名をリンク化）

Closes #118