### PR TITLE
fix: ログアウトをbutton_toに変更しInstantClick対策を整理 #120

### DIFF
--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "タイムライン - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
@@ -9,7 +9,7 @@
     <% end %>
     <div class="flex items-center gap-3">
       <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
-      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors", data: { turbo_prefetch: false } %>
+      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer" %>
     </div>
   </div>
 </nav>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "sengen - 宣言すると、動き出せる。" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
@@ -9,7 +9,7 @@
     <% end %>
     <div class="flex gap-2">
       <% if user_signed_in? %>
-        <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors" %>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer" %>
       <% else %>
         <%= link_to "ログイン", new_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors" %>
         <%= link_to "新規登録", new_user_registration_path, class: "bg-blue-600 text-white rounded-lg px-4 py-1.5 text-sm hover:bg-blue-700 transition-colors" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "プロフィール編集 - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "プロフィール - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
@@ -9,7 +9,7 @@
     <% end %>
     <div class="flex items-center gap-3">
       <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
-      <%= link_to "ログアウト", destroy_user_session_path, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors", data: { turbo_prefetch: false } %>
+      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer" %>
     </div>
   </div>
 </nav>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "新規登録 - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "ログイン - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, "#{@user.name} - sengen" %>
-<% content_for :head do %><meta name="turbo-cache-control" content="no-cache"><% end %>
+
 
 <!-- ナビバー -->
 <nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">


### PR DESCRIPTION
## Summary
- ログアウトリンクを`link_to` → `button_to`に変更し、InstantClick（ホバープリフェッチ）による誤遷移を根本解決
- 不要になった`data-turbo-prefetch="false"`を削除
- 不要になった`<meta name="turbo-cache-control" content="no-cache">`を全ページから削除

Closes #120