### PR TITLE
fix: Deviseのsign_out_viaをdeleteに変更 #120

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -269,7 +269,7 @@ Devise.setup do |config|
   config.navigational_formats = [ "*/*", :html, :turbo_stream ]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting


### PR DESCRIPTION
## Summary
- Deviseの`sign_out_via`を`:get`から`:delete`に変更
- #120でログアウトを`button_to method: :delete`に変更したが、Devise側が`:get`のままだったためログアウトが動かなかった