### PR TITLE
feat: タイムラインに期間フィルターを追加 #75

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -2,8 +2,9 @@ class DeclarationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @declarations = Declaration.includes(user: { avatar_attachment: :blob }).recent
+    @declarations = filter_by_period(Declaration.includes(user: { avatar_attachment: :blob }).recent)
     @declaration = Declaration.new(deadline: Date.today)
+    @current_period = params[:period] || "all"
   end
 
   def create
@@ -11,7 +12,8 @@ class DeclarationsController < ApplicationController
     if @declaration.save
       redirect_to root_path, notice: t("declarations.notices.created")
     else
-      @declarations = Declaration.includes(user: { avatar_attachment: :blob }).recent
+      @declarations = filter_by_period(Declaration.includes(user: { avatar_attachment: :blob }).recent)
+      @current_period = params[:period] || "all"
       flash.now[:alert] = @declaration.errors.full_messages.first
       render :index, status: :unprocessable_entity
     end
@@ -27,5 +29,20 @@ class DeclarationsController < ApplicationController
 
   def declaration_params
     params.require(:declaration).permit(:content, :deadline)
+  end
+
+  def filter_by_period(declarations)
+    case params[:period]
+    when "today"
+      declarations.where(deadline: Date.today)
+    when "this_week"
+      declarations.where(deadline: Date.today..Date.today.end_of_week)
+    when "this_month"
+      declarations.where(deadline: Date.today..Date.today.end_of_month)
+    when "later"
+      declarations.where("deadline > ?", Date.today.end_of_month)
+    else
+      declarations
+    end
   end
 end

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -77,6 +77,20 @@
       </div>
     </div>
 
+    <!-- 期間フィルター -->
+    <div class="flex border-b border-gray-200 bg-white rounded-t-2xl overflow-hidden">
+      <% [
+        ["すべて", "all"],
+        ["今日", "today"],
+        ["今週中", "this_week"],
+        ["今月中", "this_month"],
+        ["来月以降", "later"]
+      ].each do |label, period| %>
+        <%= link_to label, declarations_path(period: period),
+            class: "flex-1 py-3 text-sm font-semibold text-center border-b-2 transition-colors #{@current_period == period ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
+      <% end %>
+    </div>
+
     <!-- 宣言カード一覧 -->
     <% if @declarations.empty? %>
       <div class="text-center py-16 text-gray-400">


### PR DESCRIPTION
- タイムラインに「すべて / 今日 / 今週中 / 今月中 / 来月以降」の期間フィルタータブを追加
- 締切日（deadline）を基準にフィルタリング
- デフォルトは「すべて」

Closes #75