### PR TITLE
feat: フォロー/フォロー解除機能を追加 #85

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,15 @@
+class RelationshipsController < ApplicationController
+    before_action :authenticate_user!
+
+    def create
+      @user = User.find(params[:following_id])
+      current_user.follow(@user)
+      redirect_back fallback_location: user_path(@user)
+    end
+
+    def destroy
+      relationship = current_user.active_relationships.find(params[:id])
+      relationship.destroy
+      redirect_back fallback_location: user_path(relationship.following)
+    end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,13 @@
+class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :following, class_name: "User"
+
+  validates :follower_id, uniqueness: { scope: :following_id }
+  validate :cannot_follow_self
+
+  private
+
+  def cannot_follow_self
+    errors.add(:follower_id) if follower_id == following_id
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,28 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  validates :name, presence: true
+    # Include default devise modules. Others available are:
+    # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+    validates :name, presence: true
 
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+    devise :database_authenticatable, :registerable,
+           :recoverable, :rememberable, :validatable
 
-  has_many :declarations, dependent: :destroy
-  has_one_attached :avatar
+    has_many :declarations, dependent: :destroy
+    has_one_attached :avatar
+
+    has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy
+    has_many :passive_relationships, class_name: "Relationship", foreign_key: "following_id", dependent: :destroy
+    has_many :followings, through: :active_relationships, source: :following
+    has_many :followers, through: :passive_relationships, source: :follower
+
+    def follow(user)
+      followings << user unless self == user || following?(user)
+    end
+
+    def unfollow(user)
+      active_relationships.find_by(following_id: user.id)&.destroy
+    end
+
+    def following?(user)
+      followings.include?(user)
+    end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -56,6 +56,10 @@
           <% else %>
             <p class="text-gray-300 text-sm mt-2">自己紹介を追加しましょう</p>
           <% end %>
+          <div class="flex gap-4 mt-2">
+            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= current_user.followings.count %></span> フォロー</p>
+            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= current_user.followers.count %></span> フォロワー</p>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,10 +30,25 @@
           <% end %>
         </div>
         <div class="flex-1 min-w-0">
-          <p class="font-bold text-gray-800 text-lg"><%= @user.name %></p>
+          <div class="flex items-center justify-between">
+            <p class="font-bold text-gray-800 text-lg"><%= @user.name %></p>
+            <% if @user != current_user %>
+              <% if current_user.following?(@user) %>
+                <%= button_to "フォロー中", relationship_path(current_user.active_relationships.find_by(following_id: @user.id)),
+                    method: :delete, class: "border border-gray-300 text-gray-600 rounded-lg px-4 py-1.5 text-sm hover:bg-gray-50 transition-colors cursor-pointer" %>
+              <% else %>
+                <%= button_to "フォローする", relationships_path(following_id: @user.id),
+                    class: "bg-blue-600 text-white rounded-lg px-4 py-1.5 text-sm font-semibold hover:bg-blue-700 transition-colors cursor-pointer" %>
+              <% end %>
+            <% end %>
+          </div>
           <% if @user.bio.present? %>
             <p class="text-gray-500 text-sm mt-2 leading-relaxed"><%= @user.bio %></p>
           <% end %>
+          <div class="flex gap-4 mt-2">
+            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= @user.followings.count %></span> フォロー</p>
+            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= @user.followers.count %></span> フォロワー</p>
+          </div>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   resource :profile, only: [ :show, :edit, :update ]
   resources :users, only: [ :show ]
 
+  resources :relationship, only: [ :create, :destroy ]
+
   resources :declarations, only: [ :index, :create ] do
     member do
       patch :complete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resource :profile, only: [ :show, :edit, :update ]
   resources :users, only: [ :show ]
 
-  resources :relationship, only: [ :create, :destroy ]
+  resources :relationships, only: [ :create, :destroy ]
 
   resources :declarations, only: [ :index, :create ] do
     member do

--- a/db/migrate/20260531085641_create_relationships.rb
+++ b/db/migrate/20260531085641_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[8.1]
+  def change
+    create_table :relationships do |t|
+      t.references :follower, null: false, foreign_key: { to_table: :users }
+      t.references :following, null: false, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+    add_index :relationships, [:follower_id, :following_id], unique: true
+  end
+end

--- a/db/migrate/20260531085641_create_relationships.rb
+++ b/db/migrate/20260531085641_create_relationships.rb
@@ -5,6 +5,6 @@ class CreateRelationships < ActiveRecord::Migration[8.1]
       t.references :following, null: false, foreign_key: { to_table: :users }
       t.timestamps
     end
-    add_index :relationships, [:follower_id, :following_id], unique: true
+    add_index :relationships, [ :follower_id, :following_id ], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_23_062429) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_31_085641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_062429) do
     t.index ["user_id"], name: "index_declarations_on_user_id"
   end
 
+  create_table "relationships", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "follower_id", null: false
+    t.bigint "following_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["follower_id", "following_id"], name: "index_relationships_on_follower_id_and_following_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
+    t.index ["following_id"], name: "index_relationships_on_following_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.text "bio"
     t.datetime "created_at", null: false
@@ -69,4 +79,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_062429) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "declarations", "users"
+  add_foreign_key "relationships", "users", column: "follower_id"
+  add_foreign_key "relationships", "users", column: "following_id"
 end


### PR DESCRIPTION
- Relationshipモデルを追加し、ユーザー間のフォロー関係を管理
- フォロー/フォロー解除ボタンを他ユーザーのプロフィールページに配置
- フォロー数・フォロワー数をプロフィールページに表示

## 変更ファイル
- `db/migrate/xxx_create_relationships.rb` — テーブル作成
- `app/models/relationship.rb` — 関連付け・バリデーション
- `app/models/user.rb` — フォロー関連付け・メソッド追加
- `app/controllers/relationships_controller.rb` — フォロー/解除アクション
- `config/routes.rb` — ルーティング追加
- `app/views/users/show.html.erb` — フォローボタン・フォロー数表示
- `app/views/profiles/show.html.erb` — フォロー数表示

Closes #85