### PR TITLE
feat: プロフィールのタブを廃止し統計カードに切り替え機能を持たせる #126

### DIFF
--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -8,10 +8,22 @@ export default class extends Controller {
 
     this.tabTargets.forEach(tab => {
       const active = tab.dataset.tab === selected
-      tab.classList.toggle("border-blue-600", active)
-      tab.classList.toggle("text-blue-600", active)
-      tab.classList.toggle("border-transparent", !active)
-      tab.classList.toggle("text-gray-500", !active)
+      if (tab.dataset.tabStyle === "card") {
+        tab.classList.toggle("border-2", active)
+        tab.classList.toggle("border-blue-600", active)
+        tab.classList.toggle("border", !active)
+        tab.classList.toggle("border-gray-200", !active)
+        const label = tab.querySelector("[data-tab-label]")
+        if (label) {
+          label.classList.toggle("text-blue-600", active)
+          label.classList.toggle("text-gray-400", !active)
+        }
+      } else {
+        tab.classList.toggle("border-blue-600", active)
+        tab.classList.toggle("text-blue-600", active)
+        tab.classList.toggle("border-transparent", !active)
+        tab.classList.toggle("text-gray-500", !active)
+      }
     })
 
     this.panelTargets.forEach(panel => {

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -65,57 +65,62 @@
     </div>
 
     <!-- 統計 -->
-    <div class="grid grid-cols-5 gap-3">
-      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+    <div data-controller="tabs" class="grid grid-cols-5 gap-3">
+      <button data-tabs-target="tab" data-tab="all" data-tab-style="card" data-action="click->tabs#switch"
+        class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center cursor-pointer hover:bg-gray-50 transition-colors">
         <p class="text-2xl font-bold text-gray-800"><%= @declarations.count %></p>
-        <p class="text-xs text-gray-400 mt-1">宣言数</p>
-      </div>
-      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p data-tab-label class="text-xs text-gray-400 mt-1">宣言数</p>
+      </button>
+      <button data-tabs-target="tab" data-tab="declaring" data-tab-style="card" data-action="click->tabs#switch"
+        class="bg-white rounded-2xl shadow-sm border-2 border-blue-600 p-4 text-center cursor-pointer hover:bg-gray-50 transition-colors">
         <p class="text-2xl font-bold text-gray-800"><%= @declaring.count %></p>
-        <p class="text-xs text-gray-400 mt-1">宣言中</p>
-      </div>
-      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p data-tab-label class="text-xs text-blue-600 mt-1">宣言中</p>
+      </button>
+      <button data-tabs-target="tab" data-tab="pending" data-tab-style="card" data-action="click->tabs#switch"
+        class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center cursor-pointer hover:bg-gray-50 transition-colors">
         <p class="text-2xl font-bold text-gray-800"><%= @pending.count %></p>
-        <p class="text-xs text-gray-400 mt-1">未達成</p>
-      </div>
-      <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
+        <p data-tab-label class="text-xs text-gray-400 mt-1">未達成</p>
+      </button>
+      <button data-tabs-target="tab" data-tab="completed" data-tab-style="card" data-action="click->tabs#switch"
+        class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center cursor-pointer hover:bg-gray-50 transition-colors">
         <p class="text-2xl font-bold text-gray-800"><%= @completed.count %></p>
-        <p class="text-xs text-gray-400 mt-1">達成</p>
-      </div>
+        <p data-tab-label class="text-xs text-gray-400 mt-1">達成</p>
+      </button>
       <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-4 text-center">
         <p class="text-2xl font-bold text-gray-800"><%= @completion_rate %>%</p>
         <p class="text-xs text-gray-400 mt-1">達成率</p>
       </div>
-    </div>
 
-    <!-- タブ -->
-    <div data-controller="tabs">
-      <div class="flex border-b border-gray-200 bg-white rounded-t-2xl overflow-hidden">
-        <button
-          data-tabs-target="tab"
-          data-tab="declaring"
-          data-action="click->tabs#switch"
-          class="flex-1 py-3 text-sm font-semibold border-b-2 border-blue-600 text-blue-600 transition-colors">
-          宣言中（<%= @declaring.count %>）
-        </button>
-        <button
-          data-tabs-target="tab"
-          data-tab="pending"
-          data-action="click->tabs#switch"
-          class="flex-1 py-3 text-sm font-semibold border-b-2 border-transparent text-gray-500 transition-colors">
-          未達成（<%= @pending.count %>）
-        </button>
-        <button
-          data-tabs-target="tab"
-          data-tab="completed"
-          data-action="click->tabs#switch"
-          class="flex-1 py-3 text-sm font-semibold border-b-2 border-transparent text-gray-500 transition-colors">
-          達成（<%= @completed.count %>）
-        </button>
+      <!-- 全宣言パネル -->
+      <div data-tabs-target="panel" data-panel="all" class="hidden col-span-5 space-y-3 pt-3">
+        <% if @declarations.empty? %>
+          <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+            <p class="text-sm">宣言はありません</p>
+          </div>
+        <% else %>
+          <% @declarations.each do |declaration| %>
+            <div class="<%= if declaration.completed? then 'bg-blue-100 border-blue-200' elsif declaration.pending? then 'bg-red-100 border-red-200' else 'bg-white border-gray-200' end %> rounded-2xl shadow-sm border p-5">
+              <div class="flex gap-3">
+                <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                  <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                  </svg>
+                </div>
+                <div class="flex-1 min-w-0">
+                  <p class="font-bold text-gray-800 mb-2"><%= current_user.name %></p>
+                  <div class="<%= if declaration.completed? || declaration.pending? then 'bg-white' else 'bg-gray-50' end %> rounded-lg px-4 py-3 mb-3">
+                    <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
+                  </div>
+                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
       </div>
 
       <!-- 宣言中パネル -->
-      <div data-tabs-target="panel" data-panel="declaring" class="space-y-3 pt-3">
+      <div data-tabs-target="panel" data-panel="declaring" class="col-span-5 space-y-3 pt-3">
         <% if @declaring.empty? %>
           <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
             <p class="text-sm">宣言中の宣言はありません</p>
@@ -143,7 +148,7 @@
       </div>
 
       <!-- 未達成パネル -->
-      <div data-tabs-target="panel" data-panel="pending" class="hidden space-y-3 pt-3">
+      <div data-tabs-target="panel" data-panel="pending" class="hidden col-span-5 space-y-3 pt-3">
         <% if @pending.empty? %>
           <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
             <p class="text-sm">進行中の宣言はありません</p>
@@ -171,7 +176,7 @@
       </div>
 
       <!-- 達成パネル -->
-      <div data-tabs-target="panel" data-panel="completed" class="hidden space-y-3 pt-3">
+      <div data-tabs-target="panel" data-panel="completed" class="hidden col-span-5 space-y-3 pt-3">
         <% if @completed.empty? %>
           <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
             <p class="text-sm">達成した宣言はありません</p>


### PR DESCRIPTION
- プロフィール画面のタブUIを廃止
- 統計カード（宣言数・宣言中・未達成・達成）をクリックで該当の宣言一覧を表示
- デフォルトは「宣言中」を選択状態
- タブコントローラーをカードスタイルに対応（既存のタブUIにも影響なし）

Closes #126