### PR TITLE
feat: タイムラインにフォロー中フィルターを追加 #117

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -2,9 +2,10 @@ class DeclarationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @declarations = filter_by_period(Declaration.includes(user: { avatar_attachment: :blob }).recent)
+    @declarations = filter_by_period(filter_by_scope(Declaration.includes(user: { avatar_attachment: :blob }).recent))
     @declaration = Declaration.new(deadline: Date.today)
     @current_period = params[:period] || "all"
+    @current_scope = params[:scope] || "all"
   end
 
   def create
@@ -12,8 +13,9 @@ class DeclarationsController < ApplicationController
     if @declaration.save
       redirect_to root_path, notice: t("declarations.notices.created")
     else
-      @declarations = filter_by_period(Declaration.includes(user: { avatar_attachment: :blob }).recent)
+      @declarations = filter_by_period(filter_by_scope(Declaration.includes(user: { avatar_attachment: :blob }).recent))
       @current_period = params[:period] || "all"
+      @current_scope = params[:scope] || "all"
       flash.now[:alert] = @declaration.errors.full_messages.first
       render :index, status: :unprocessable_entity
     end
@@ -29,6 +31,16 @@ class DeclarationsController < ApplicationController
 
   def declaration_params
     params.require(:declaration).permit(:content, :deadline)
+  end
+
+  def filter_by_scope(declarations)
+    case params[:scope]
+    when "following"
+      following_ids = current_user.following_ids + [ current_user.id ]
+      declarations.where(user_id: following_ids)
+    else
+      declarations
+    end
   end
 
   def filter_by_period(declarations)

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -77,8 +77,19 @@
       </div>
     </div>
 
+    <!-- スコープフィルター -->
+    <div class="flex bg-white rounded-t-2xl overflow-hidden border-b border-gray-200">
+      <% [
+        ["すべて", "all"],
+        ["フォロー中", "following"]
+      ].each do |label, scope| %>
+        <%= link_to label, declarations_path(scope: scope, period: @current_period),
+            class: "flex-1 py-3 text-sm font-semibold text-center border-b-2 transition-colors #{@current_scope == scope ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
+      <% end %>
+    </div>
+
     <!-- 期間フィルター -->
-    <div class="flex border-b border-gray-200 bg-white rounded-t-2xl overflow-hidden">
+    <div class="flex bg-white overflow-hidden border-b border-gray-200">
       <% [
         ["すべて", "all"],
         ["今日", "today"],
@@ -86,8 +97,8 @@
         ["今月中", "this_month"],
         ["来月以降", "later"]
       ].each do |label, period| %>
-        <%= link_to label, declarations_path(period: period),
-            class: "flex-1 py-3 text-sm font-semibold text-center border-b-2 transition-colors #{@current_period == period ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 hover:text-gray-700'}" %>
+        <%= link_to label, declarations_path(period: period, scope: @current_scope),
+            class: "flex-1 py-2.5 text-xs font-medium text-center transition-colors #{@current_period == period ? 'text-blue-600 bg-blue-50' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50'}" %>
       <% end %>
     </div>
 


### PR DESCRIPTION
## Summary
- タイムラインに「すべて / フォロー中」タブを期間フィルターの上に追加
- デフォルトは「すべて」（全ユーザーの宣言を表示）
- 「フォロー中」選択時はフォロー中のユーザー＋自分の宣言のみ表示
- 期間フィルターとの併用が可能

Closes #117