### PR TITLE
feat: フォロー/フォロワー一覧ページを追加 #116

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,4 +10,16 @@ class UsersController < ApplicationController
     judged = @pending.count + @completed.count
     @completion_rate = judged > 0 ? (@completed.count * 100 / judged) : 0
   end
+
+  def followings
+    @user = User.find(params[:id])
+    @users = @user.followings.includes(avatar_attachment: :blob)
+    @title = "フォロー中"
+  end
+
+  def followers
+    @user = User.find(params[:id])
+    @users = @user.followers.includes(avatar_attachment: :blob)
+    @title = "フォロワー"
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -57,8 +57,8 @@
             <p class="text-gray-300 text-sm mt-2">自己紹介を追加しましょう</p>
           <% end %>
           <div class="flex gap-4 mt-2">
-            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= current_user.followings.count %></span> フォロー</p>
-            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= current_user.followers.count %></span> フォロワー</p>
+            <%= link_to followings_user_path(current_user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.followings.count %></span> フォロー<% end %>
+            <%= link_to followers_user_path(current_user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.followers.count %></span> フォロワー<% end %>
           </div>
         </div>
       </div>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, "#{@user.name}の#{@title} - sengen" %>
+
+<!-- ナビバー -->
+<nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
+  <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
+    <% end %>
+    <div class="flex items-center gap-3">
+      <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
+    </div>
+  </div>
+</nav>
+
+<div class="min-h-screen bg-gray-50 pt-16">
+  <div class="max-w-2xl mx-auto px-4 py-6 space-y-4">
+
+    <!-- ヘッダー -->
+    <div class="flex items-center gap-3">
+      <%= link_to user_path(@user), class: "text-gray-400 hover:text-gray-600 transition-colors" do %>
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+      <% end %>
+      <p class="font-bold text-gray-800 text-lg"><%= @user.name %>の<%= @title %></p>
+    </div>
+
+    <!-- ユーザー一覧 -->
+    <% if @users.empty? %>
+      <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+        <p class="text-sm"><%= @title %>はいません</p>
+      </div>
+    <% else %>
+      <% @users.each do |user| %>
+        <%= link_to user_path(user), class: "block bg-white rounded-2xl shadow-sm border border-gray-200 p-4 hover:bg-gray-50 transition-colors" do %>
+          <div class="flex items-center gap-3">
+            <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+              <% if user.avatar.attached? %>
+                <%= image_tag user.avatar, class: "h-full w-full object-cover" %>
+              <% else %>
+                <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                </svg>
+              <% end %>
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-bold text-gray-800"><%= user.name %></p>
+              <% if user.bio.present? %>
+                <p class="text-gray-500 text-sm truncate"><%= user.bio %></p>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/users/followings.html.erb
+++ b/app/views/users/followings.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, "#{@user.name}の#{@title} - sengen" %>
+
+<!-- ナビバー -->
+<nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
+  <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
+    <% end %>
+    <div class="flex items-center gap-3">
+      <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
+    </div>
+  </div>
+</nav>
+
+<div class="min-h-screen bg-gray-50 pt-16">
+  <div class="max-w-2xl mx-auto px-4 py-6 space-y-4">
+
+    <!-- ヘッダー -->
+    <div class="flex items-center gap-3">
+      <%= link_to user_path(@user), class: "text-gray-400 hover:text-gray-600 transition-colors" do %>
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+      <% end %>
+      <p class="font-bold text-gray-800 text-lg"><%= @user.name %>の<%= @title %></p>
+    </div>
+
+    <!-- ユーザー一覧 -->
+    <% if @users.empty? %>
+      <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+        <p class="text-sm"><%= @title %>はいません</p>
+      </div>
+    <% else %>
+      <% @users.each do |user| %>
+        <%= link_to user_path(user), class: "block bg-white rounded-2xl shadow-sm border border-gray-200 p-4 hover:bg-gray-50 transition-colors" do %>
+          <div class="flex items-center gap-3">
+            <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+              <% if user.avatar.attached? %>
+                <%= image_tag user.avatar, class: "h-full w-full object-cover" %>
+              <% else %>
+                <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                </svg>
+              <% end %>
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-bold text-gray-800"><%= user.name %></p>
+              <% if user.bio.present? %>
+                <p class="text-gray-500 text-sm truncate"><%= user.bio %></p>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -46,8 +46,8 @@
             <p class="text-gray-500 text-sm mt-2 leading-relaxed"><%= @user.bio %></p>
           <% end %>
           <div class="flex gap-4 mt-2">
-            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= @user.followings.count %></span> フォロー</p>
-            <p class="text-sm text-gray-500"><span class="font-bold text-gray-800"><%= @user.followers.count %></span> フォロワー</p>
+            <%= link_to followings_user_path(@user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= @user.followings.count %></span> フォロー<% end %>
+            <%= link_to followers_user_path(@user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= @user.followers.count %></span> フォロワー<% end %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,12 @@ Rails.application.routes.draw do
   root "pages#landing"
 
   resource :profile, only: [ :show, :edit, :update ]
-  resources :users, only: [ :show ]
+  resources :users, only: [ :show ] do
+    member do
+      get :followings
+      get :followers
+    end
+  end
 
   resources :relationships, only: [ :create, :destroy ]
 


### PR DESCRIPTION
## Summary
- フォロー中・フォロワーの一覧ページを追加（`/users/:id/followings`, `/users/:id/followers`）
- プロフィールのフォロー数・フォロワー数をクリックで一覧ページに遷移するようリンク化
- 一覧から各ユーザーのプロフィールに遷移可能

Closes #116