### PR TITLE
feat: 見届け機能を追加 #84

### DIFF
--- a/app/controllers/declarations_controller.rb
+++ b/app/controllers/declarations_controller.rb
@@ -2,7 +2,7 @@ class DeclarationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @declarations = filter_by_period(filter_by_scope(Declaration.includes(user: { avatar_attachment: :blob }).recent))
+    @declarations = filter_by_period(filter_by_scope(Declaration.includes(:witnesses, user: { avatar_attachment: :blob }).recent))
     @declaration = Declaration.new(deadline: Date.today)
     @current_period = params[:period] || "all"
     @current_scope = params[:scope] || "all"
@@ -13,7 +13,7 @@ class DeclarationsController < ApplicationController
     if @declaration.save
       redirect_to root_path, notice: t("declarations.notices.created")
     else
-      @declarations = filter_by_period(filter_by_scope(Declaration.includes(user: { avatar_attachment: :blob }).recent))
+      @declarations = filter_by_period(filter_by_scope(Declaration.includes(:witnesses, user: { avatar_attachment: :blob }).recent))
       @current_period = params[:period] || "all"
       @current_scope = params[:scope] || "all"
       flash.now[:alert] = @declaration.errors.full_messages.first

--- a/app/controllers/witnesses_controller.rb
+++ b/app/controllers/witnesses_controller.rb
@@ -1,0 +1,15 @@
+class WitnessesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @declaration = Declaration.find(params[:declaration_id])
+    current_user.witnesses.create(declaration: @declaration) unless @declaration.user == current_user
+    redirect_back fallback_location: root_path
+  end
+
+  def destroy
+    witness = current_user.witnesses.find(params[:id])
+    witness.destroy
+    redirect_back fallback_location: root_path
+  end
+end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,5 +1,6 @@
 class Declaration < ApplicationRecord
   belongs_to :user
+  has_many :witnesses, dependent: :destroy
 
   enum :status, { pending: 0, completed: 1, declaring: 2 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
            :recoverable, :rememberable, :validatable
 
     has_many :declarations, dependent: :destroy
+    has_many :witnesses, dependent: :destroy
     has_one_attached :avatar
 
     has_many :active_relationships, class_name: "Relationship", foreign_key: "follower_id", dependent: :destroy

--- a/app/models/witness.rb
+++ b/app/models/witness.rb
@@ -1,0 +1,6 @@
+class Witness < ApplicationRecord
+  belongs_to :user
+  belongs_to :declaration
+
+  validates :user_id, uniqueness: { scope: :declaration_id }
+end

--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -130,22 +130,43 @@
               </div>
               <div class="flex items-center justify-between">
                 <span class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></span>
-                <% if declaration.completed? %>
-                  <span class="flex items-center gap-1.5 text-green-600 text-sm font-semibold bg-green-50 px-4 py-1.5 rounded-full">
-                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                    </svg>
-                    達成！
-                  </span>
-                <% elsif declaration.user == current_user %>
-                  <button
-                    data-action="click->achieve#open"
-                    data-content="<%= declaration.content %>"
-                    data-url="<%= complete_declaration_path(declaration) %>"
-                    class="bg-blue-600 text-white rounded-lg px-4 py-1.5 text-sm font-semibold hover:bg-blue-700 transition-colors cursor-pointer">
-                    達成報告
-                  </button>
-                <% end %>
+                <div class="flex items-center gap-2">
+                  <% if declaration.user != current_user %>
+                    <% witness = declaration.witnesses.find_by(user: current_user) %>
+                    <% if witness %>
+                      <%= button_to witness_path(witness), method: :delete, class: "flex items-center gap-1.5 text-blue-600 text-sm font-semibold bg-blue-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-blue-100 transition-colors" do %>
+                        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
+                        </svg>
+                        見届け中
+                      <% end %>
+                    <% else %>
+                      <%= button_to witnesses_path(declaration_id: declaration.id), class: "flex items-center gap-1.5 text-gray-500 text-sm bg-gray-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-gray-100 transition-colors" do %>
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        見届ける
+                      <% end %>
+                    <% end %>
+                  <% end %>
+                  <% if declaration.completed? %>
+                    <span class="flex items-center gap-1.5 text-green-600 text-sm font-semibold bg-green-50 px-4 py-1.5 rounded-full">
+                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                      </svg>
+                      達成！
+                    </span>
+                  <% elsif declaration.user == current_user %>
+                    <button
+                      data-action="click->achieve#open"
+                      data-content="<%= declaration.content %>"
+                      data-url="<%= complete_declaration_path(declaration) %>"
+                      class="bg-blue-600 text-white rounded-lg px-4 py-1.5 text-sm font-semibold hover:bg-blue-700 transition-colors cursor-pointer">
+                      達成報告
+                    </button>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -111,7 +111,18 @@
                   <div class="<%= if declaration.completed? || declaration.pending? then 'bg-white' else 'bg-gray-50' end %> rounded-lg px-4 py-3 mb-3">
                     <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
                   </div>
-                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                  <div class="flex items-center justify-between">
+                    <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                    <% if declaration.witnesses.any? %>
+                      <span class="flex items-center gap-1 text-gray-400 text-sm">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        <%= declaration.witnesses.count %>人が見届け中
+                      </span>
+                    <% end %>
+                  </div>
                 </div>
               </div>
             </div>
@@ -139,7 +150,18 @@
                   <div class="bg-gray-50 rounded-lg px-4 py-3 mb-3">
                     <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
                   </div>
-                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                  <div class="flex items-center justify-between">
+                    <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                    <% if declaration.witnesses.any? %>
+                      <span class="flex items-center gap-1 text-gray-400 text-sm">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        <%= declaration.witnesses.count %>人が見届け中
+                      </span>
+                    <% end %>
+                  </div>
                 </div>
               </div>
             </div>
@@ -167,7 +189,18 @@
                   <div class="bg-white rounded-lg px-4 py-3 mb-3">
                     <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
                   </div>
-                  <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                  <div class="flex items-center justify-between">
+                    <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                    <% if declaration.witnesses.any? %>
+                      <span class="flex items-center gap-1 text-gray-400 text-sm">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        <%= declaration.witnesses.count %>人が見届け中
+                      </span>
+                    <% end %>
+                  </div>
                 </div>
               </div>
             </div>
@@ -196,7 +229,18 @@
                     <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
                   </div>
                   <div class="flex items-center justify-between">
+                    <div class="flex items-center justify-between">
                     <p class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></p>
+                    <% if declaration.witnesses.any? %>
+                      <span class="flex items-center gap-1 text-gray-400 text-sm">
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                        </svg>
+                        <%= declaration.witnesses.count %>人が見届け中
+                      </span>
+                    <% end %>
+                  </div>
                     <span class="flex items-center gap-1.5 text-green-600 text-sm font-semibold bg-green-50 px-4 py-1.5 rounded-full">
                       <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   end
 
   resources :relationships, only: [ :create, :destroy ]
+  resources :witnesses, only: [ :create, :destroy ]
 
   resources :declarations, only: [ :index, :create ] do
     member do

--- a/db/migrate/20260603110626_create_witnesses.rb
+++ b/db/migrate/20260603110626_create_witnesses.rb
@@ -1,0 +1,11 @@
+class CreateWitnesses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :witnesses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :declaration, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :witnesses, [ :user_id, :declaration_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_31_085641) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_110626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -76,9 +76,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_31_085641) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "witnesses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "declaration_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["declaration_id"], name: "index_witnesses_on_declaration_id"
+    t.index ["user_id", "declaration_id"], name: "index_witnesses_on_user_id_and_declaration_id", unique: true
+    t.index ["user_id"], name: "index_witnesses_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "declarations", "users"
   add_foreign_key "relationships", "users", column: "follower_id"
   add_foreign_key "relationships", "users", column: "following_id"
+  add_foreign_key "witnesses", "declarations"
+  add_foreign_key "witnesses", "users"
 end


### PR DESCRIPTION
## Summary
- 宣言に対して「見届ける」ボタンを追加（いいね機能の代わり）
- 他ユーザーの宣言にのみ表示、自分の宣言には非表示
- 見届け中の場合はボタンが「見届け中」に変わり、再クリックで解除
- 見届け人数は本人のプロフィールページでのみ表示

## 変更ファイル
- `db/migrate/xxx_create_witnesses.rb` — テーブル作成
- `app/models/witness.rb` — バリデーション付きモデル
- `app/models/user.rb` — witnesses関連付け追加
- `app/models/declaration.rb` — witnesses関連付け追加
- `app/controllers/witnesses_controller.rb` — create/destroyアクション
- `config/routes.rb` — ルーティング追加
- `app/views/declarations/index.html.erb` — 見届けボタン追加
- `app/views/profiles/show.html.erb` — 見届け人数表示

Closes #84