### PR TITLE
feat: プロフィールの自己紹介を一言メッセージに変更 #74

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -45,10 +45,10 @@
                 class: "w-full border border-gray-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" %>
           </div>
           <div>
-            <%= f.label :bio, "自己紹介", class: "block text-sm font-medium text-gray-700 mb-1" %>
+            <%= f.label :bio, "一言メッセージ", class: "block text-sm font-medium text-gray-700 mb-1" %>
             <%= f.text_area :bio,
                 rows: 4,
-                placeholder: "自己紹介を入力してください",
+                placeholder: "一言メッセージを入力してください",
                 class: "w-full border border-gray-300 rounded-lg px-4 py-2.5 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent" %>
           </div>
           <%= f.submit "保存する",

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -54,7 +54,7 @@
           <% if current_user.bio.present? %>
             <p class="text-gray-500 text-sm mt-2 leading-relaxed"><%= current_user.bio %></p>
           <% else %>
-            <p class="text-gray-300 text-sm mt-2">自己紹介を追加しましょう</p>
+            <p class="text-gray-300 text-sm mt-2">一言メッセージを追加しましょう</p>
           <% end %>
           <div class="flex gap-4 mt-2">
             <%= link_to followings_user_path(current_user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.followings.count %></span> フォロー<% end %>


### PR DESCRIPTION
## Summary
- プロフィール編集フォームのラベル・プレースホルダーを「自己紹介」→「一言メッセージ」に変更
- 未設定時の案内文も変更

Closes #74