### PR TITLE
feat: お問い合わせページを作成 #70

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,4 +10,7 @@ class PagesController < ApplicationController
 
   def terms_of_service
   end
+
+  def contact
+  end
 end

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, "お問い合わせ - sengen" %>
+
+<!-- ナビバー -->
+<nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
+  <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
+    <% end %>
+    <div class="flex items-center gap-3">
+      <% if user_signed_in? %>
+        <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <% else %>
+        <%= link_to "ログイン", new_user_session_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <% end %>
+    </div>
+  </div>
+</nav>
+
+<div class="min-h-screen bg-gray-50 pt-16">
+  <div class="max-w-2xl mx-auto px-4 py-6 space-y-6">
+
+    <!-- ヘッダー -->
+    <div class="text-center pt-4 pb-2">
+      <h1 class="text-xl font-bold text-gray-800">お問い合わせ</h1>
+    </div>
+
+    <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 space-y-4">
+      <p class="text-sm text-gray-600 leading-relaxed">
+        sengenに関するご質問・ご要望・不具合の報告などがございましたら、以下のメールアドレスまでお気軽にご連絡ください。
+      </p>
+      <div class="bg-gray-50 rounded-lg px-4 py-3 text-center">
+        <p class="text-sm text-gray-500 mb-1">メールアドレス</p>
+        <a href="mailto:ddki313kr2@gmail.com" class="text-blue-600 font-semibold hover:underline">ddki313kr2@gmail.com</a>
+      </div>
+      <p class="text-xs text-gray-400">
+        ※ 返信までにお時間をいただく場合がございます。あらかじめご了承ください。
+      </p>
+    </div>
+
+  </div>
+</div>

--- a/app/views/pages/landing.html.erb
+++ b/app/views/pages/landing.html.erb
@@ -103,7 +103,7 @@
     <div class="flex gap-6 text-gray-500 text-sm">
       <%= link_to "利用規約", terms_of_service_path, class: "hover:text-gray-900 transition-colors" %>
       <%= link_to "プライバシー", privacy_policy_path, class: "hover:text-gray-900 transition-colors" %>
-      <span class="text-gray-500 cursor-not-allowed">お問い合わせ</span>
+      <%= link_to "お問い合わせ", contact_path, class: "hover:text-gray-900 transition-colors" %>
     </div>
     <p class="text-gray-500 text-sm">&copy; 2026 sengen</p>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,5 +26,6 @@ Rails.application.routes.draw do
   get "how_to_use" => "pages#how_to_use", as: :how_to_use
   get "privacy_policy" => "pages#privacy_policy", as: :privacy_policy
   get "terms_of_service" => "pages#terms_of_service", as: :terms_of_service
+  get "contact" => "pages#contact", as: :contact
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## 概要
- `/contact`にお問い合わせページを作成
- メールアドレスを表示（後日フォーム送信に変更予定）
- ランディングページのフッターからリンク

Closes #70