### PR TITLE
feat: 見届け一覧ページを追加 #147

### DIFF
--- a/app/controllers/witnesses_controller.rb
+++ b/app/controllers/witnesses_controller.rb
@@ -1,6 +1,13 @@
 class WitnessesController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @declarations = Declaration.joins(:witnesses)
+      .where(witnesses: { user_id: current_user.id })
+      .includes(:witnesses, user: { avatar_attachment: :blob })
+      .recent
+  end
+
   def create
     @declaration = Declaration.find(params[:declaration_id])
     current_user.witnesses.create(declaration: @declaration) unless @declaration.user == current_user

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -60,6 +60,7 @@
           <div class="flex gap-4 mt-2">
             <%= link_to followings_user_path(current_user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.followings.count %></span> フォロー<% end %>
             <%= link_to followers_user_path(current_user), class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.followers.count %></span> フォロワー<% end %>
+            <%= link_to witnesses_path, class: "text-sm text-gray-500 hover:underline" do %><span class="font-bold text-gray-800"><%= current_user.witnesses.count %></span> 見届け中<% end %>
           </div>
         </div>
       </div>

--- a/app/views/witnesses/index.html.erb
+++ b/app/views/witnesses/index.html.erb
@@ -1,0 +1,69 @@
+<% content_for :title, "見届け中の宣言 - sengen" %>
+
+<!-- ナビバー -->
+<nav class="fixed top-0 left-0 right-0 z-50 bg-white/75 backdrop-blur-md border-b border-gray-200">
+  <div class="mx-auto pl-0 pr-6 h-16 flex justify-between items-center max-w-5xl">
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "sengen", class: "h-10 w-auto -ml-12" %>
+    <% end %>
+    <div class="flex items-center gap-3">
+      <%= link_to "ホーム", root_path, class: "text-gray-600 text-sm hover:text-gray-900 transition-colors" %>
+      <%= link_to current_user.name, profile_path, class: "text-gray-600 text-sm font-medium hover:text-gray-900 transition-colors" %>
+    </div>
+  </div>
+</nav>
+
+<div class="min-h-screen bg-gray-50 pt-16">
+  <div class="max-w-2xl mx-auto px-4 py-6 space-y-4">
+
+    <!-- ヘッダー -->
+    <div class="flex items-center gap-3">
+      <%= link_to profile_path, class: "text-gray-400 hover:text-gray-600 transition-colors" do %>
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+        </svg>
+      <% end %>
+      <p class="font-bold text-gray-800 text-lg">見届け中の宣言</p>
+    </div>
+
+    <% if @declarations.empty? %>
+      <div class="text-center py-12 text-gray-400 bg-white rounded-2xl border border-gray-200">
+        <p class="text-sm">見届け中の宣言はありません</p>
+      </div>
+    <% else %>
+      <% @declarations.each do |declaration| %>
+        <div class="<%= if declaration.completed? then 'bg-blue-100 border-blue-200' elsif declaration.pending? then 'bg-red-100 border-red-200' else 'bg-white border-gray-200' end %> rounded-2xl shadow-sm border p-5">
+          <div class="flex gap-3">
+            <div class="h-10 w-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 overflow-hidden">
+              <% if declaration.user.avatar.attached? %>
+                <%= image_tag declaration.user.avatar, class: "h-full w-full object-cover" %>
+              <% else %>
+                <svg class="h-6 w-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+                </svg>
+              <% end %>
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="font-bold text-gray-800 mb-2"><%= link_to declaration.user.name, user_path(declaration.user), class: "hover:underline" %></p>
+              <div class="<%= if declaration.completed? || declaration.pending? then 'bg-white' else 'bg-gray-50' end %> rounded-lg px-4 py-3 mb-3">
+                <p class="text-gray-700 text-sm leading-relaxed"><%= declaration.content %></p>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="text-gray-400 text-sm"><%= declaration.deadline.strftime("%Y/%m/%d") %></span>
+                <% if declaration.completed? %>
+                  <span class="flex items-center gap-1.5 text-green-600 text-sm font-semibold bg-green-50 px-4 py-1.5 rounded-full">
+                    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                    </svg>
+                    達成！
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 
   resources :relationships, only: [ :create, :destroy ]
-  resources :witnesses, only: [ :create, :destroy ]
+  resources :witnesses, only: [ :create, :destroy, :index ]
 
   resources :declarations, only: [ :index, :create ] do
     member do


### PR DESCRIPTION
## 概要
- `/witnesses`に自分が見届けている宣言の一覧ページを作成
- 宣言カードにステータスに応じた色分け・達成バッジを表示
- プロフィールページに「見届け中」リンクを追加

Closes #147