### PR TITLE
fix: 見届けボタンのアイコンを削除して文字のみに変更 #149

### DIFF
--- a/app/views/declarations/index.html.erb
+++ b/app/views/declarations/index.html.erb
@@ -135,20 +135,9 @@
                   <% if declaration.user != current_user %>
                     <% witness = declaration.witnesses.find_by(user: current_user) %>
                     <% if witness %>
-                      <%= button_to witness_path(witness), method: :delete, class: "flex items-center gap-1.5 text-blue-600 text-sm font-semibold bg-blue-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-blue-100 transition-colors" do %>
-                        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"/>
-                        </svg>
-                        見届け中
-                      <% end %>
+                      <%= button_to "見届け中", witness_path(witness), method: :delete, class: "text-blue-600 text-sm font-semibold bg-blue-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-blue-100 transition-colors" %>
                     <% else %>
-                      <%= button_to witnesses_path(declaration_id: declaration.id), class: "flex items-center gap-1.5 text-gray-500 text-sm bg-gray-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-gray-100 transition-colors" do %>
-                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-                        </svg>
-                        見届ける
-                      <% end %>
+                      <%= button_to "見届ける", witnesses_path(declaration_id: declaration.id), class: "text-gray-500 text-sm bg-gray-50 px-4 py-1.5 rounded-full cursor-pointer hover:bg-gray-100 transition-colors" %>
                     <% end %>
                   <% end %>
                   <% if declaration.completed? %>


### PR DESCRIPTION
## 概要
- タイムラインの見届けボタンから目のアイコン（SVG）を削除
- テキストのみのシンプルな表示に変更

Closes #149