### PR TITLE
fix: タイムゾーンをTokyoに設定 #152

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module Myapp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
## 概要
- config.time_zoneが未設定（UTC）のため、日本時間0時〜8時59分に過去日の宣言ができてしまうバグを修正
- タイムゾーンをTokyoに設定

Closes #152